### PR TITLE
Fix install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ ARGS:
 
 ## Installation
 ```sh
-$ cargo add crossgen
+$ cargo install crossgen
 ```
 
 ## License


### PR DESCRIPTION
🔦 documentation change

If I understand correctly it's `cargo install` to install binaries from crates.io, and `cargo add` is for adding dependencies to a project