### PR TITLE
Read Cargo.toml from target dir

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use cargo_toml::TomlManifest;
 use crossgen::Cli;
 use exitfailure::ExitFailure;
 use std::fs::read;
+use std::path::PathBuf;
 use structopt::StructOpt;
 
 fn main() -> Result<(), ExitFailure> {
@@ -27,7 +28,7 @@ fn main() -> Result<(), ExitFailure> {
   let name = args.name()?;
   let lib = args.lib();
 
-  let manifest = TomlManifest::from_slice(&read("Cargo.toml")?)?;
+  let manifest = TomlManifest::from_slice(&read(dir.join("Cargo.toml"))?)?;
   let repo = manifest
     .package
     .repository


### PR DESCRIPTION
When running `crossgen` on a directory with a missing `Cargo.toml` it
would panic with an error message.

Debugging what happend, I've found it failed to find a `Cargo.toml` file, as it don't exist.
To my surprise, when I've cloned the repo and tried to reproduce using `cargo run -- ~/path/to/my-dir`, there was no panic!

This happened because the `Cargo.toml` was found on `crossgen` repo, not on my targe repo, as expected.

This commit changes the location of the manifest file to use the directory parsed from the arguments.

<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

**Choose one:** is this a 🐛 bug fix, a 🙋 feature, or a 🔦 documentation change?
🐛

<!-- Provide a general summary of the changes in the title above -->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] tests pass
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Context
<!-- Is this related to any GitHub issue(s)? -->
Related issue while debugging: https://github.com/rust-clique/human-panic/issues/30#issuecomment-428393228 and https://github.com/yoshuawuyts/crossgen/issues/16

## Semver Changes
<!-- Which semantic version change would you recommend? -->
