### PR TITLE
Improve lib template on Travis

### DIFF
--- a/templates/lib/before_deploy.sh
+++ b/templates/lib/before_deploy.sh
@@ -6,21 +6,43 @@ set -ex
 
 main() {
   local src=$(pwd) \
-    stage=
+  stage \
+  linking_args
 
   case $TRAVIS_OS_NAME in
-    linux)
-      stage=$(mktemp -d)
-      ;;
-    osx)
-      stage=$(mktemp -d -t tmp)
-      ;;
+  linux)
+    stage=$(mktemp -d)
+    ;;
+  osx)
+    stage=$(mktemp -d -t tmp)
+    ;;
   esac
 
   test -f Cargo.lock || cargo generate-lockfile
 
-  cross rustc --bin $PKG_NAME --target $TARGET --release -- -C lto
-  cp target/$TARGET/release/$PKG_NAME $stage/
+  # TODO: combine with -C lto
+  case $TYPE in
+  static)
+    linking_args="--crate-type staticlib"
+    ;;
+  *)
+    linking_args="--crate-type cdylib"
+    ;;
+  esac
+
+  cross rustc --lib --target $TARGET --release -- $linking_args
+
+  case $TYPE-$TRAVIS_OS_NAME in
+  static-*)
+    cp target/$TARGET/release/lib$PKG_NAME.a $stage/
+    ;;
+  *-osx)
+    cp target/$TARGET/release/lib$PKG_NAME.dylib $stage/
+    ;;
+  *)
+    cp target/$TARGET/release/lib$PKG_NAME.so $stage/
+    ;;
+  esac
 
   cd $stage
   tar czf $src/$CRATE_NAME-$TRAVIS_TAG-$TARGET.tar.gz *

--- a/templates/lib/before_deploy.sh
+++ b/templates/lib/before_deploy.sh
@@ -5,9 +5,7 @@ PKG_NAME="{{PKG_NAME}}"
 set -ex
 
 main() {
-  local src=$(pwd) \
-  stage \
-  linking_args
+  local src=$(pwd) stage
 
   case $TRAVIS_OS_NAME in
   linux)
@@ -20,17 +18,13 @@ main() {
 
   test -f Cargo.lock || cargo generate-lockfile
 
-  # TODO: combine with -C lto
-  case $TYPE in
-  static)
-    linking_args="--crate-type staticlib"
-    ;;
-  *)
-    linking_args="--crate-type cdylib"
-    ;;
-  esac
+  if [[ "$TYPE" == "static" ]]; then
+    cargo crate-type static
+  else
+    cargo crate-type dynamic
+  fi
 
-  cross rustc --lib --target $TARGET --release -- $linking_args
+  cross rustc --lib --target $TARGET --release -- -C lto
 
   case $TYPE-$TRAVIS_OS_NAME in
   static-*)

--- a/templates/lib/install.sh
+++ b/templates/lib/install.sh
@@ -46,6 +46,9 @@ main() {
   # Install test dependencies
   rustup component add rustfmt-preview
   rustup component add clippy-preview
+
+  # For defining the type of lib to produce: dynamic OR static
+  cargo install --force cargo-crate-type
 }
 
 main

--- a/templates/lib/travis.yml
+++ b/templates/lib/travis.yml
@@ -12,7 +12,7 @@ matrix:
   include:
     - env: TARGET=armv7-unknown-linux-gnueabihf
       rust: nightly
-    - env: TARGET=x86_64-unknown-linux-musl
+    - env: TARGET=x86_64-unknown-linux-musl TYPE=static
       rust: nightly
     - env: TARGET=x86_64-apple-darwin
       rust: nightly


### PR DESCRIPTION
This commit contains changes on the generated lib template to build
cross-platform libs. With this changes, I was able to setup a [Travis]
build with GitHub [Releases] of a cross-platform lib.

It is not possible yet to build a different crate type only using
command line args. It requires a modification on `Cargo.toml` to include
new types of library outputs. I've already opened an issue on [cargo](https://github.com/rust-lang/cargo/issues/6160) to see what should be the case here.

Meanwhile, lib authors must change `Cargo.toml` and include the extra
`crate-type` attribute with all the libs. Sadly, this also means that
`LTO` optimisation is not available if the lib uses `lib` or `rlib`
attributes.

To avoid modifying the `Cargo.toml`, the sugestion would be that on a
future PR we could add to the deploy script a modification on the
`Cargo.toml` manifest to include the corresponding crate-type, and only
such crate type for that target. This means we would be able to bring
LTO and output smaller libs.

[Travis]: https://travis-ci.org/bltavares/rust-over-jna-example/builds/439439854
[Releases]: https://github.com/bltavares/rust-over-jna-example/releases/tag/initial

<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

**Choose one:** is this a 🐛 bug fix, a 🙋 feature, or a 🔦 documentation change?
🙋

<!-- Provide a general summary of the changes in the title above -->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] tests pass
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Context
- https://github.com/yoshuawuyts/crossgen/issues/11

## Semver Changes
<!-- Which semantic version change would you recommend? -->
